### PR TITLE
Add build config file

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,12 @@
+# Build plan from the provider
+[phases.setup]
+nixPkgs = ["nodejs", "yarn"]
+
+[phases.install]
+cmds = ["npm install -g yarn", "yarn install"]
+
+[phases.build]
+cmds = ["yarn build"]
+
+[start]
+cmd = "yarn start"


### PR DESCRIPTION
This file gives us more flexibility to configure how we're building and running our project on Railway. Our build was failing, because it uses NPM by default.

Tested locally:
![image](https://user-images.githubusercontent.com/19495917/193435118-2cb1a191-adae-4873-931c-f2e736bb38cd.png)
