### PR TITLE
Hotfix: undefined user when listing rides

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -148,15 +148,21 @@ const handleExistingRide = async (
     return
   }
 
-  await cleanRides(chatId)
-
+  const removedRides = await cleanRides(chatId)
   const [direction] = options
+  const directionField = direction === 'ida' ? 'going' : 'coming'
 
-  let success = await rideManager.setRideFull(chatId, {
-    userId: user.id,
-    direction: options[0] === 'ida' ? 'going' : 'coming',
-    state: command === '/lotou' ? 1 : 0
-  })
+  let success: boolean
+
+  if (removedRides && removedRides[`${directionField}.${user.id}`] === '') {
+    success = false
+  } else {
+    success = await rideManager.setRideFull(chatId, {
+      userId: user.id,
+      direction: directionField,
+      state: command === '/lotou' ? 1 : 0
+    })
+  }
 
   const replyMsg = createFullRideMessage(success, {
     direction,
@@ -178,10 +184,7 @@ const listRides = async (chatId: number) => {
   })
 }
 
-const cleanRides = async (chatId: number) => {
-  const currentTime = getCurrentTime()
-  await rideManager.cleanRides(chatId, currentTime)
-}
+const cleanRides = async (chatId: number) => await rideManager.cleanRides(chatId, getCurrentTime())
 
 const handleRemoveRide = async (
   command: string,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -113,6 +113,8 @@ const handleNewRide = async (
     return
   }
 
+  await cleanRides(chatId)
+
   const rideDate = setRideDateAndTime(now, rideTime, isToday)
 
   let wasModified = await rideManager.addRide(chatId, {
@@ -146,6 +148,8 @@ const handleExistingRide = async (
     return
   }
 
+  await cleanRides(chatId)
+
   const [direction] = options
 
   let success = await rideManager.setRideFull(chatId, {
@@ -163,18 +167,20 @@ const handleExistingRide = async (
     reply_to_message_id: messageId
   })
 
-  await listRides(chatId)
+  listRides(chatId)
 }
 
 const listRides = async (chatId: number) => {
-  const currentTime = getCurrentTime()
-  await rideManager.cleanRides(chatId, currentTime)
-
   rideManager.listRidesAsString(chatId).then((msg: string) => {
     msg != ''
       ? tgBot.sendMessage(chatId, msg, { parse_mode: 'HTML' })
       : tgBot.sendMessage(chatId, 'Nenhuma carona cadastrada até o momento.')
   })
+}
+
+const cleanRides = async (chatId: number) => {
+  const currentTime = getCurrentTime()
+  await rideManager.cleanRides(chatId, currentTime)
 }
 
 const handleRemoveRide = async (
@@ -188,6 +194,8 @@ const handleRemoveRide = async (
     tgBot.sendMessage(chatId, command + ' ida/volta')
     return
   }
+
+  await cleanRides(chatId)
 
   const [direction] = options
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -60,7 +60,7 @@ tgBot.on('text', async (msg) => {
       break
 
     case '/say':
-      sendAdminMessageToGroup(user, params)
+      await sendAdminMessageToGroup(user, params)
       break
 
     default:
@@ -173,16 +173,15 @@ const handleExistingRide = async (
     reply_to_message_id: messageId
   })
 
-  listRides(chatId)
+  await listRides(chatId)
 }
 
-const listRides = async (chatId: number) => {
+const listRides = async (chatId: number) =>
   rideManager.listRidesAsString(chatId).then((msg: string) => {
     msg != ''
       ? tgBot.sendMessage(chatId, msg, { parse_mode: 'HTML' })
       : tgBot.sendMessage(chatId, 'Nenhuma carona cadastrada até o momento.')
   })
-}
 
 const cleanRides = async (chatId: number) => await rideManager.cleanRides(chatId, getCurrentTime())
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,11 +11,7 @@ export class Database {
   }
 
   connect = () => {
-    this._client.connect((err: any, _: any) => {
-      if (err) throw err
-      console.log('Connected to the MongoDB')
-    })
-
+    this._client.connect().finally(() => console.log('Connected to the MongoDB'))
     const db: Db = this._client.db(process.env.DB_NAME)
 
     const ridesCollection: Collection = db.collection(MONGO_COLLECTION_NAME)
@@ -28,10 +24,10 @@ export class Database {
   }
 
   disconnect = () =>
-    this._client.close((err: any, _: any) => {
-      if (err) throw err
-      console.log('Closed the MongoDB connection')
-    })
+    this._client.close().then(
+      () => console.log('Closed connection with MongoDB'),
+      (reason: any) => console.log(`Close connection was unsuccessfull. Reason: ${reason}`)
+    )
 
   scrapeGroupRides = (chatId: number): Promise<Group[]> =>
     this._collection?.find({ chatId: chatId }).toArray() as Promise<unknown> as Promise<Group[]>

--- a/src/rideManager.ts
+++ b/src/rideManager.ts
@@ -56,7 +56,7 @@ export default class RideManager {
     chatId: number,
     rideInfo: { userId: number; direction: string; state: number }
   ): Promise<boolean> {
-    return await this.db.updateGroup(
+    return this.db.updateGroup(
       chatId,
       {
         $set: {

--- a/src/rideManager.ts
+++ b/src/rideManager.ts
@@ -162,7 +162,7 @@ export default class RideManager {
 
       // If it is full, generate strikethrough text.
       if (ride.full === 1) {
-        rideInfo = ride.user.first_name + ' ' + (ride.user.last_name || '') + rideInfo
+        rideInfo = ride.user?.first_name + ' ' + (ride.user.last_name || '') + rideInfo
         message += format.strikeThrough(rideInfo) + '\n'
       }
       // If it is not, create a link for the user.

--- a/src/rideManager.ts
+++ b/src/rideManager.ts
@@ -89,6 +89,8 @@ export default class RideManager {
       },
       { upsert: false }
     )
+
+    return ridesToApply
   }
 
   public async listRidesAsString(chatId: number): Promise<string> {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -26,7 +26,7 @@ export const createFullRideMessage = (
 ) => {
   return wasSuccessful
     ? `Estado da sua carona de ${params.direction} alterado.`
-    : `, ou você não possui uma ${params.userFirstName} cadastrada, ou já passou do horário cadastrado.`
+    : `${params.userFirstName}, ou você não possui uma carona cadastrada, ou já passou do horário.`
 }
 
 export const getUserLink = (id: number, name: string, lastName: string): string =>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -26,7 +26,7 @@ export const createFullRideMessage = (
 ) => {
   return wasSuccessful
     ? `Estado da sua carona de ${params.direction} alterado.`
-    : `, você não possui uma ${params.userFirstName} cadastrada.`
+    : `, ou você não possui uma ${params.userFirstName} cadastrada, ou já passou do horário cadastrado.`
 }
 
 export const getUserLink = (id: number, name: string, lastName: string): string =>


### PR DESCRIPTION
The user may try to update a ride that has already passed. In those cases, we do not want to update it on the db, because it would lead to a scenario of an empty document that was causing problems whenever listing the rides. Therefore, we chose to clean the rides first, changing the message to the user accordingly in case a ride no longer exists.

In the current implementation, an exception is thrown, and there is no try-catch to prevent the service from dying because of the exception, leading to restarts and messages not being replied to.