### PR TITLE
Fix rides listing

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -47,6 +47,7 @@ tgBot.on('text', async (msg) => {
       break
 
     case '/lista':
+      await cleanRides(chatId)
       await listRides(chatId)
       break
 


### PR DESCRIPTION
We were not cleaning the rides before listing, leading to a scenario where old rides were kept.